### PR TITLE
Add tick_time, sync_limit and init_limit to config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,9 @@ class zookeeper::config(
   $rollingfile_threshold = 'ERROR',
   $tracefile_threshold   = 'TRACE',
   $max_allowed_connections = 10,
+  $tick_time = 2000,
+  $init_limit = 10,
+  $sync_limit = 5,
 ) {
   require zookeeper::install
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,9 @@ class zookeeper(
   $rollingfile_threshold = 'ERROR',
   $tracefile_threshold    = 'TRACE',
   $max_allowed_connections = 10,
+  $tick_time = 2000,
+  $init_limit = 10,
+  $sync_limit = 5,
 ) {
 
   anchor { 'zookeeper::start': }->
@@ -69,6 +72,9 @@ class zookeeper(
     rollingfile_threshold   => $rollingfile_threshold,
     tracefile_threshold     => $tracefile_threshold,
     max_allowed_connections => $max_allowed_connections,
+    tick_time               => $tick_time,
+    init_limit              => $init_limit,
+    sync_limit              => $sync_limit,
   }->
   class { 'zookeeper::service':
     cfg_dir => $cfg_dir,

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -1,13 +1,13 @@
 # http://hadoop.apache.org/zookeeper/docs/current/zookeeperAdmin.html
 
 # The number of milliseconds of each tick
-tickTime=2000
+tickTime=<%= scope.lookupvar('zookeeper::config::tick_time') %>
 # The number of ticks that the initial
 # synchronization phase can take
-initLimit=10
+initLimit=<%= scope.lookupvar('zookeeper::config::init_limit') %>
 # The number of ticks that can pass between
 # sending a request and getting an acknowledgement
-syncLimit=5
+syncLimit=<%= scope.lookupvar('zookeeper::config::sync_limit') %>
 # the directory where the snapshot is stored.
 dataDir=<%= scope.lookupvar('zookeeper::config::datastore') %>
 # Place the dataLogDir to a separate physical disc for better performance


### PR DESCRIPTION
This gives us more configuration options we need for large zk clusters... this is a bad way to pass params but w.e. it's consistent.