### PR TITLE
Add a parameter for custom log4j properties file.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class zookeeper(
   # interval in hours, purging enabled when >= 1
   $purge_interval   = 0,
   # log4j properties
+  $log4j_file   = undef,
   $rollingfile_threshold = 'ERROR',
   $tracefile_threshold    = 'TRACE',
   $max_allowed_connections = 10,
@@ -75,6 +76,7 @@ class zookeeper(
     tick_time               => $tick_time,
     init_limit              => $init_limit,
     sync_limit              => $sync_limit,
+    log4j_file              => $log4j_file,
   }->
   class { 'zookeeper::service':
     cfg_dir => $cfg_dir,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -77,6 +77,19 @@ describe 'zookeeper::config' do
     }
   end
 
+  context 'log4j file' do
+    let(:params) { {
+      :log4j_file    => "/nail/etc/zookeeper/log4j.properties",
+    } }
+
+    it do
+      should contain_file('/etc/zookeeper/conf/log4j.properties').with(
+          'ensure' => 'link',
+          'target' => log4j_file,
+      )
+    end
+  end
+
   context 'max allowed connections' do
     max_conn = 15
 


### PR DESCRIPTION
Many a time (such as logging to multiple files with ROLLING appender) it is
a better to pass a custom file (templated higher up in modules calling
this module) to which /etc/zookeeper/conf/log4j.properties is
symlinked.

Also updated the spec tests.