### PR TITLE
Unmanage files from dataDir and logDir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,6 @@ class zookeeper::config(
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    recurse => false,
     mode    => '0644',
   }
 
@@ -84,7 +83,6 @@ class zookeeper::config(
     owner   => $user,
     group   => $group,
     mode    => '0644',
-    recurse => false,
   }
 
   file { "${cfg_dir}/myid":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,7 @@ class zookeeper::config(
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    recurse => true,
+    recurse => false,
     mode    => '0644',
   }
 
@@ -84,7 +84,7 @@ class zookeeper::config(
     owner   => $user,
     group   => $group,
     mode    => '0644',
-    recurse => true,
+    recurse => false,
   }
 
   file { "${cfg_dir}/myid":


### PR DESCRIPTION
We shouldnt be recursing into the dataDir, and logDir. This causes puppet to blow up with huge state files on all zookeeper boxes, causing ooms.