### PR TITLE
support setting datalogstore

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,6 +28,7 @@
 class zookeeper::config(
   $id                    = '1',
   $datastore             = '/var/lib/zookeeper',
+  $datalogstore          = '/var/lib/zookeeper',
   $client_port           = 2181,
   $snap_count            = 10000,
   $log_dir               = '/var/log/zookeeper',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,7 +28,7 @@
 class zookeeper::config(
   $id                    = '1',
   $datastore             = '/var/lib/zookeeper',
-  $datalogstore          = '/var/lib/zookeeper',
+  $datalogstore          = undef,
   $client_port           = 2181,
   $snap_count            = 10000,
   $log_dir               = '/var/log/zookeeper',
@@ -86,7 +86,7 @@ class zookeeper::config(
     mode    => '0644',
   }
 
-  if $datalogstore and ($datalogstore != $datastore) {
+  if $datalogstore {
     file { $datalogstore:
       ensure  => directory,
       owner   => $user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,6 +86,15 @@ class zookeeper::config(
     mode    => '0644',
   }
 
+  if $datalogstore and ($datalogstore != $datastore) {
+    file { $datalogstore:
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      mode    => '0644',
+    }
+  }
+
   file { "${cfg_dir}/myid":
     ensure  => file,
     content => template('zookeeper/conf/myid.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@
 class zookeeper(
   $id          = '1',
   $datastore   = '/var/lib/zookeeper',
+  $datalogstore  = '/var/lib/zookeeper',
   $client_port = 2181,
   $log_dir     = '/var/log/zookeeper',
   $cfg_dir     = '/etc/zookeeper/conf',
@@ -56,6 +57,7 @@ class zookeeper(
   class { 'zookeeper::config':
     id                      => $id,
     datastore               => $datastore,
+    datalogstore            => $datalogstore,
     client_port             => $client_port,
     log_dir                 => $log_dir,
     cfg_dir                 => $cfg_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 class zookeeper(
   $id          = '1',
   $datastore   = '/var/lib/zookeeper',
-  $datalogstore  = '/var/lib/zookeeper',
+  $datalogstore  = undef,
   $client_port = 2181,
   $log_dir     = '/var/log/zookeeper',
   $cfg_dir     = '/etc/zookeeper/conf',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -101,4 +101,14 @@ describe 'zookeeper::config' do
         '/etc/zookeeper/conf/zoo.cfg'
       ).with_content(/maxClientCnxns=#{max_conn}/) }
   end
+
+  context 'datalogstore' do
+    let(:params)  {{
+      :datalogstore => '/tmp/log'
+
+    }}
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/dataLogDir=\/tmp\/log/) }
+  end
 end

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -12,7 +12,7 @@ syncLimit=<%= scope.lookupvar('zookeeper::config::sync_limit') %>
 dataDir=<%= scope.lookupvar('zookeeper::config::datastore') %>
 # Place the dataLogDir to a separate physical disc for better performance
 # dataLogDir=/disk2/zookeeper
-<% if scope.lookupvar('zookeeper::config::datalogstore') != scope.lookupvar('zookeeper::config:datastore') %>
+<% if scope.lookupvar('zookeeper::config::datalogstore') %>
 dataLogDir=<%= scope.lookupvar('zookeeper::config::datalogstore') %>
 <% end%>
 # the port at which the clients will connect

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -12,7 +12,9 @@ syncLimit=<%= scope.lookupvar('zookeeper::config::sync_limit') %>
 dataDir=<%= scope.lookupvar('zookeeper::config::datastore') %>
 # Place the dataLogDir to a separate physical disc for better performance
 # dataLogDir=/disk2/zookeeper
-
+<% if scope.lookupvar('zookeeper::config::datalogstore') != scope.lookupvar('zookeeper::config:datastore') %>
+dataLogDir=<%= scope.lookupvar('zookeeper::config::datalogstore') %>
+<% end%>
 # the port at which the clients will connect
 clientPort=<%= scope.lookupvar('zookeeper::config::client_port') %>
 


### PR DESCRIPTION
allows users to separate the location logs are stored to the snapshots.
set the template so that this change has no diff where this is not set