### PR TITLE
Add config variable to toggle notifying zookeeper service

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class zookeeper::config(
   $init_limit = 10,
   $sync_limit = 5,
   $log4j_file = undef,
+  $restart_zookeeper = true,
 ) {
   require zookeeper::install
 
@@ -62,6 +63,12 @@ class zookeeper::config(
     if $log4j_file == "${cfg_dir}/log4j.properties" {
         fail('log4j_file should not be same as ' + "${cfg_dir}/log4j.properties")
     }
+  }
+
+  if $restart_zookeeper {
+    $notify_services = [Class['zookeeper::service']]
+  } else {
+    $notify_services = []
   }
 
   file { $cfg_dir:
@@ -102,7 +109,7 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     require => File[$cfg_dir],
-    notify  => Class['zookeeper::service'],
+    notify  => $notify_services,
   }
 
   file { "${cfg_dir}/zoo.cfg":
@@ -110,7 +117,7 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     content => template('zookeeper/conf/zoo.cfg.erb'),
-    notify  => Class['zookeeper::service'],
+    notify  => $notify_services,
   }
 
   file { "${cfg_dir}/environment":
@@ -118,7 +125,7 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     content => template('zookeeper/conf/environment.erb'),
-    notify  => Class['zookeeper::service'],
+    notify  => $notify_services,
   }
 
   if $log4j_file {
@@ -129,7 +136,7 @@ class zookeeper::config(
         mode    => '0644',
         target  => $log4j_file,
         require => File[$log4j_file],
-        notify  => Class['zookeeper::service'],
+        notify  => $notify_services,
     }
   } else {
     file { "${cfg_dir}/log4j.properties":
@@ -137,7 +144,7 @@ class zookeeper::config(
         group   => $group,
         mode    => '0644',
         content => template('zookeeper/conf/log4j.properties.erb'),
-        notify  => Class['zookeeper::service'],
+        notify  => $notify_services,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 #   user
 #   group
 #   log_dir
+#   restart_zookeeper: enables automatic restarts of zookeeper after config changes
 #
 # Requires:
 #   N/A
@@ -44,6 +45,7 @@ class zookeeper(
   $tick_time = 2000,
   $init_limit = 10,
   $sync_limit = 5,
+  $restart_zookeeper = true,
 ) {
 
   anchor { 'zookeeper::start': }->
@@ -79,6 +81,7 @@ class zookeeper(
     init_limit              => $init_limit,
     sync_limit              => $sync_limit,
     log4j_file              => $log4j_file,
+    restart_zookeeper       => $restart_zookeeper,
   }->
   class { 'zookeeper::service':
     cfg_dir => $cfg_dir,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -111,4 +111,46 @@ describe 'zookeeper::config' do
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/dataLogDir=\/tmp\/log/) }
   end
+
+  context 'restart zookeeper default' do
+    it { should contain_file(
+      '/etc/zookeeper/conf/myid'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/environment'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/log4j.properties'
+    ).that_notifies('Class[zookeeper::service]') }
+  end
+
+  context 'restart zookeeper false' do
+    let(:params)  {{
+      :restart_zookeeper => false
+
+    }}
+    it { should contain_file(
+      '/etc/zookeeper/conf/myid') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/environment') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/log4j.properties') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/myid'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/environment'
+    ).that_notifies('Class[zookeeper::service]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/log4j.properties'
+    ).that_notifies('Class[zookeeper::service]') }
+  end
 end


### PR DESCRIPTION
This allows us to incrementally roll out disabling of automatic puppet restarts of zookeeper so that we can fully adopt our tool to safely restart zookeeper clusters.