### PR TITLE
Add xenial and systemd support.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/deric/puppet-zookeeper'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 0.1.6'
+dependency 'camptocamp/puppet-systemd'

--- a/files/zookeeper.service
+++ b/files/zookeeper.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Zookeeper distributed coordination server
+After=network.target
+Wants=network.target
+
+[Service]
+User=zookeeper
+Group=zookeeper
+SyslogIdentifier=zookeeper
+ExecStart=/bin/bash -c 'source /etc/default/zookeeper && exec /usr/share/zookeeper/bin/zkServer.sh start-foreground'
+Restart=always
+# This is due to zookeeper exiting with 143 when SIGTERM is sent by init.
+SuccessExitStatus=143
+LimitNOFILE=120000
+
+[Install]
+WantedBy=multi-user.target

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,25 +80,25 @@ class zookeeper::config(
   }
 
   file { $log_dir:
-    ensure  => directory,
-    owner   => $user,
-    group   => $group,
-    mode    => '0644',
+    ensure => directory,
+    owner  => $user,
+    group  => $group,
+    mode   => '0644',
   }
 
   file { $datastore:
-    ensure  => directory,
-    owner   => $user,
-    group   => $group,
-    mode    => '0644',
+    ensure => directory,
+    owner  => $user,
+    group  => $group,
+    mode   => '0644',
   }
 
   if $datalogstore {
     file { $datalogstore:
-      ensure  => directory,
-      owner   => $user,
-      group   => $group,
-      mode    => '0644',
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => '0644',
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,10 +23,22 @@ class zookeeper::install(
     ensure => $ensure
   }
 
-  package { ['zookeeperd']: #init.d scripts for zookeeper
-    ensure  => $ensure,
-    require => Package['zookeeper']
-  }
+  if $::lsbdistcodename == 'xenial' {
+      systemd::unit_file { 'zookeeper.service':
+          # enable/active => true is not required here since
+          # that also enables the automated restarted of zookeeper
+          # which we manage through service.pp and notify.
+          source  => 'puppet:///modules/zookeeper/zookeeper.service',
+          require => Package['zookeeper'],
+          before =>  Service['zookeeper'],
+      }
+  } else {
+    package { ['zookeeperd']: #init.d scripts for zookeeper
+      ensure  => $ensure,
+      require => Package['zookeeper'],
+      before =>  Service['zookeeper'],
+    }
+ }
 
   # if !$cleanup_count, then ensure this cron is absent.
   if ($snap_retain_count > 0 and $ensure != 'absent') {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,7 +11,6 @@ class zookeeper::service(
     hasrestart => true,
     enable     => true,
     require    => [
-      Package['zookeeperd'],
       File["${cfg_dir}/zoo.cfg"]
     ]
   }


### PR DESCRIPTION
- Added unit file for zookeeper.service.
- Xenial related updates.
    + zookeeperd not required with systemd.


Tested with deployment branches and is essentially no-op on existing trusty nodes.