### PR TITLE
rspec test fixes and updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,14 @@ before_install:
   - gem update --system 2.1.11
   - gem --version
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
+  - 2.1.0
 script: 'bundle exec rake spec'
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.0.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 4.3.0"
 matrix:
   exclude:
-    # No support for Ruby 1.9 before Puppet 2.7
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=2.6.0
     # No support for Ruby 2.0 before Puppet 3.2
     - rvm: 2.0.0
       env: PUPPET_VERSION="~> 2.7.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'puppet',  '>= 2.7.0'
-gem 'puppet-lint', '>=0.3.2'
-gem 'puppetlabs_spec_helper', '>=0.2.0'
-gem 'rake',         '>=0.9.2.2'
+gem 'puppet', '4.5.3'
+gem 'puppet-lint', '2.0.2'
+gem 'puppetlabs_spec_helper', '~> 1.1.0'
+gem 'rake',         '11.1.1'
+gem 'rake-hooks', '1.2.3'
 gem 'librarian-puppet', '>=0.9.10'
-gem 'rspec-system-puppet',     :require => false
-gem 'serverspec',              :require => false
-gem 'rspec-system-serverspec', :require => false
 gem 'hiera-puppet-helper', :git => 'https://github.com/mmz-srf/hiera-puppet-helper.git'
 gem 'puppet-blacksmith',  :git => 'https://github.com/maestrodev/puppet-blacksmith.git'
-gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+
+gem 'rspec', '~> 3.4.0'                    # MIT
+gem 'rspec-core', '~> 3.4.4'               # MIT
+gem 'rspec-puppet', '2.6.10'               # MIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 GIT
   remote: https://github.com/maestrodev/puppet-blacksmith.git
-  revision: adeb613d78dc1e9971ad175ecd5d3b66465ba927
+  revision: d62d39dac4620cf4542a10cbba7328555726dc7d
   specs:
-    puppet-blacksmith (2.0.2)
-      nokogiri
-      puppet (>= 2.7.16)
-      rest-client
+    puppet-blacksmith (4.1.2)
+      rest-client (~> 2.0)
 
 GIT
   remote: https://github.com/mmz-srf/hiera-puppet-helper.git
@@ -13,101 +11,96 @@ GIT
   specs:
     hiera-puppet-helper (2.0.1)
 
-GIT
-  remote: https://github.com/rodjek/rspec-puppet.git
-  revision: 03e94422fb9bbdd950d5a0bec6ead5d76e06616b
-  specs:
-    rspec-puppet (1.0.1)
-      rspec
-
 GEM
   remote: https://rubygems.org/
   specs:
-    builder (3.2.2)
-    diff-lcs (1.2.5)
-    excon (0.31.0)
-    facter (1.7.4)
-    fog (1.19.0)
-      builder
-      excon (~> 0.31.0)
-      formatador (~> 0.2.0)
-      mime-types
-      multi_json (~> 1.0)
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5)
-      ruby-hmac
-    formatador (0.2.4)
-    hiera (1.3.1)
-      json_pure
-    highline (1.6.20)
-    json (1.8.1)
-    json_pure (1.8.1)
-    kwalify (0.7.2)
-    librarian-puppet (0.9.10)
-      json
+    CFPropertyList (2.2.8)
+    diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    facter (2.5.1)
+      CFPropertyList (~> 2.2)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.2)
+    gettext (3.2.9)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.30)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
+    hiera (3.4.3)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json_pure (2.1.0)
+    librarian-puppet (3.0.0)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.4)
       thor (~> 0.15)
-    metaclass (0.0.2)
-    mime-types (1.25.1)
-    mocha (1.0.0)
+    locale (2.1.2)
+    metaclass (0.0.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitar (0.6.1)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    multi_json (1.8.4)
-    net-scp (1.1.2)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
-    nokogiri (1.5.11)
-    puppet (3.4.2)
-      facter (~> 1.6)
-      hiera (~> 1.0)
-      rgen (~> 0.6.5)
-    puppet-lint (0.3.2)
-    puppetlabs_spec_helper (0.4.1)
-      mocha (>= 0.10.5)
+    multipart-post (2.0.0)
+    netrc (0.11.0)
+    puppet (4.5.3)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppet-lint (2.0.2)
+    puppet-syntax (2.4.1)
       rake
-      rspec (>= 2.9.0)
-      rspec-puppet (>= 0.1.1)
-    rake (10.1.1)
-    rbvmomi (1.8.1)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rgen (0.6.6)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    rspec-system (2.8.0)
-      fog (~> 1.18)
-      kwalify (~> 0.7.2)
-      mime-types (~> 1.16)
-      net-scp (~> 1.1)
-      net-ssh (~> 2.7)
-      nokogiri (~> 1.5.10)
-      rbvmomi (~> 1.6)
-      rspec (~> 2.14)
-      systemu (~> 2.5)
-    rspec-system-puppet (2.2.1)
-      rspec-system (~> 2.0)
-    rspec-system-serverspec (2.0.1)
-      rspec-system (~> 2.0)
-      serverspec (~> 0.0)
-      specinfra (~> 0.0)
-    ruby-hmac (0.4.0)
-    serverspec (0.14.4)
-      highline
-      net-ssh
-      rspec (>= 2.13.0)
-      specinfra (>= 0.1.0)
-    specinfra (0.4.1)
-    systemu (2.6.0)
-    thor (0.18.1)
-    trollop (2.0)
+    puppet_forge (2.2.9)
+      faraday (>= 0.9.0, < 0.14.0)
+      faraday_middleware (>= 0.9.0, < 0.13.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 1.0)
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (11.1.1)
+    rake-hooks (1.2.3)
+      rake
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.6.10)
+      rspec
+    rspec-support (3.4.1)
+    rsync (1.0.9)
+    semantic_puppet (1.0.2)
+    text (1.3.1)
+    thor (0.20.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
@@ -115,12 +108,15 @@ PLATFORMS
 DEPENDENCIES
   hiera-puppet-helper!
   librarian-puppet (>= 0.9.10)
-  puppet (>= 2.7.0)
+  puppet (= 4.5.3)
   puppet-blacksmith!
-  puppet-lint (>= 0.3.2)
-  puppetlabs_spec_helper (>= 0.2.0)
-  rake (>= 0.9.2.2)
-  rspec-puppet!
-  rspec-system-puppet
-  rspec-system-serverspec
-  serverspec
+  puppet-lint (= 2.0.2)
+  puppetlabs_spec_helper (~> 1.1.0)
+  rake (= 11.1.1)
+  rake-hooks (= 1.2.3)
+  rspec (~> 3.4.0)
+  rspec-core (~> 3.4.4)
+  rspec-puppet (= 2.6.10)
+
+BUNDLED WITH
+   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,13 @@ require 'bundler'
 Bundler.require(:rake)
 
 require 'puppet-lint/tasks/puppet-lint'
-require 'rspec-system/rake_task'
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
+require 'rake/dsl_definition'
+require 'rake/hooks'
 
-PuppetLint.configuration.ignore_paths = ["spec/fixtures/modules/cron/manifests/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/fixtures/modules/cron/manifests/*.pp", "vendor/**/*"]
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
 PuppetLint.configuration.send("disable_80chars")
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,7 +54,6 @@ class zookeeper::config(
   $init_limit = 10,
   $sync_limit = 5,
   $log4j_file = undef,
-  $restart_zookeeper = true,
 ) {
   require zookeeper::install
 
@@ -63,12 +62,6 @@ class zookeeper::config(
     if $log4j_file == "${cfg_dir}/log4j.properties" {
         fail('log4j_file should not be same as ' + "${cfg_dir}/log4j.properties")
     }
-  }
-
-  if $restart_zookeeper {
-    $notify_services = [Class['zookeeper::service']]
-  } else {
-    $notify_services = []
   }
 
   file { $cfg_dir:
@@ -109,7 +102,6 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     require => File[$cfg_dir],
-    notify  => $notify_services,
   }
 
   file { "${cfg_dir}/zoo.cfg":
@@ -117,7 +109,7 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     content => template('zookeeper/conf/zoo.cfg.erb'),
-    notify  => $notify_services,
+    require => File[$cfg_dir],
   }
 
   file { "${cfg_dir}/environment":
@@ -125,7 +117,7 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     content => template('zookeeper/conf/environment.erb'),
-    notify  => $notify_services,
+    require => File[$cfg_dir],
   }
 
   if $log4j_file {
@@ -136,7 +128,6 @@ class zookeeper::config(
         mode    => '0644',
         target  => $log4j_file,
         require => File[$log4j_file],
-        notify  => $notify_services,
     }
   } else {
     file { "${cfg_dir}/log4j.properties":
@@ -144,7 +135,6 @@ class zookeeper::config(
         group   => $group,
         mode    => '0644',
         content => template('zookeeper/conf/log4j.properties.erb'),
-        notify  => $notify_services,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,15 +48,14 @@ class zookeeper(
   $restart_zookeeper = true,
 ) {
 
-  anchor { 'zookeeper::start': }->
-  class { 'zookeeper::install':
+  anchor { 'zookeeper::start': }
+  -> class { 'zookeeper::install':
     ensure            => $ensure,
     snap_retain_count => $snap_retain_count,
     datastore         => $datastore,
     user              => $user,
     cleanup_sh        => $cleanup_sh,
-  }->
-  class { 'zookeeper::config':
+  } -> class { 'zookeeper::config':
     id                      => $id,
     datastore               => $datastore,
     datalogstore            => $datalogstore,
@@ -81,12 +80,9 @@ class zookeeper(
     init_limit              => $init_limit,
     sync_limit              => $sync_limit,
     log4j_file              => $log4j_file,
-  }->
-  class { 'zookeeper::service':
-    cfg_dir => $cfg_dir,
+  }-> class { 'zookeeper::service':
+    cfg_dir           => $cfg_dir,
     restart_zookeeper => $restart_zookeeper,
-  }
-  ->
-  anchor { 'zookeeper::end': }
+  } -> anchor { 'zookeeper::end': }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,10 +81,10 @@ class zookeeper(
     init_limit              => $init_limit,
     sync_limit              => $sync_limit,
     log4j_file              => $log4j_file,
-    restart_zookeeper       => $restart_zookeeper,
   }->
   class { 'zookeeper::service':
     cfg_dir => $cfg_dir,
+    restart_zookeeper => $restart_zookeeper,
   }
   ->
   anchor { 'zookeeper::end': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,13 +30,11 @@ class zookeeper::install(
           # which we manage through service.pp and notify.
           source  => 'puppet:///modules/zookeeper/zookeeper.service',
           require => Package['zookeeper'],
-          before =>  Service['zookeeper'],
       }
   } else {
     package { ['zookeeperd']: #init.d scripts for zookeeper
       ensure  => $ensure,
       require => Package['zookeeper'],
-      before =>  Service['zookeeper'],
     }
  }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,7 +36,7 @@ class zookeeper::install(
       ensure  => $ensure,
       require => Package['zookeeper'],
     }
- }
+  }
 
   # if !$cleanup_count, then ensure this cron is absent.
   if ($snap_retain_count > 0 and $ensure != 'absent') {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,12 @@
 
 class zookeeper::service(
   $cfg_dir = '/etc/zookeeper/conf',
+  $restart_zookeeper = true,
 ){
   require zookeeper::install
+  require zookeeper::config
+  validate_bool($restart_zookeeper)
+
 
   service { 'zookeeper':
     ensure     => 'running',
@@ -13,5 +17,12 @@ class zookeeper::service(
     require    => [
       File["${cfg_dir}/zoo.cfg"]
     ]
+  }
+
+  if $restart_zookeeper {
+    File["${cfg_dir}/myid"] ~> Service['zookeeper']
+    File["${cfg_dir}/zoo.cfg"] ~> Service['zookeeper']
+    File["${cfg_dir}/environment"] ~> Service['zookeeper']
+    File["${cfg_dir}/log4j.properties"] ~> Service['zookeeper']
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -4,7 +4,7 @@ describe 'zookeeper::config' do
   shared_examples 'debian-install' do |os, codename|
     let(:facts) {{
       :operatingsystem => os,
-      :osfamily => 'Debian',
+      :osfamily => 'Ubuntu',
       :lsbdistcodename => codename,
     }}
 
@@ -26,6 +26,11 @@ describe 'zookeeper::config' do
       'group'   => group,
     }).with_content(myid) }
 
+    it { should contain_file(env_file).with({
+      'owner'   => user,
+      'group'   => group,
+    }).with_content(/NAME=zookeeper/) }
+
   end
 
   context 'on debian-like system' do
@@ -34,9 +39,10 @@ describe 'zookeeper::config' do
     let(:cfg_dir) { '/etc/zookeeper/conf' }
     let(:log_dir) { '/var/lib/zookeeper' }
     let(:id_file) { '/etc/zookeeper/conf/myid' }
+    let(:env_file) { '/etc/zookeeper/conf/environment' }
     let(:myid)    { /1/ }
 
-    it_behaves_like 'debian-install', 'Debian', 'wheezy'
+    it_behaves_like 'debian-install', 'Ubuntu', 'trusty'
   end
 
   context 'custom parameters' do
@@ -56,8 +62,9 @@ describe 'zookeeper::config' do
     let(:log_dir) { '/var/lib/zookeeper/log' }
     let(:id_file) { '/var/lib/zookeeper/conf/myid' }
     let(:myid)    { /2/ }
+    let(:env_file) { '/var/lib/zookeeper/conf/environment' }
 
-    it_behaves_like 'debian-install', 'Debian', 'wheezy'
+    it_behaves_like 'debian-install', 'Ubuntu', 'trusty'
   end
 
   context 'extra parameters' do
@@ -85,7 +92,7 @@ describe 'zookeeper::config' do
     it do
       should contain_file('/etc/zookeeper/conf/log4j.properties').with(
           'ensure' => 'link',
-          'target' => log4j_file,
+          'target' => '/nail/etc/zookeeper/log4j.properties',
       )
     end
   end
@@ -110,47 +117,5 @@ describe 'zookeeper::config' do
     it { should contain_file(
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/dataLogDir=\/tmp\/log/) }
-  end
-
-  context 'restart zookeeper default' do
-    it { should contain_file(
-      '/etc/zookeeper/conf/myid'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/zoo.cfg'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/environment'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/log4j.properties'
-    ).that_notifies('Class[zookeeper::service]') }
-  end
-
-  context 'restart zookeeper false' do
-    let(:params)  {{
-      :restart_zookeeper => false
-
-    }}
-    it { should contain_file(
-      '/etc/zookeeper/conf/myid') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/zoo.cfg') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/environment') }
-    it { should contain_file(
-      '/etc/zookeeper/conf/log4j.properties') }
-    it { should_not contain_file(
-      '/etc/zookeeper/conf/myid'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should_not contain_file(
-      '/etc/zookeeper/conf/zoo.cfg'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should_not contain_file(
-      '/etc/zookeeper/conf/environment'
-    ).that_notifies('Class[zookeeper::service]') }
-    it { should_not contain_file(
-      '/etc/zookeeper/conf/log4j.properties'
-    ).that_notifies('Class[zookeeper::service]') }
   end
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -10,7 +10,6 @@ describe 'zookeeper::install' do
 
     it { should contain_package('zookeeper') }
     it { should contain_package('zookeeperd') }
-    it { should contain_package('cron') }
 
     it {
       should contain_cron('zookeeper-cleanup').with({
@@ -30,11 +29,10 @@ describe 'zookeeper::install' do
 
     let(:params) { {
       :snap_retain_count => 1,
+      :ensure => 'present',
     } }
 
-    it_behaves_like 'debian-install', 'Debian', 'squeeze'
-    it_behaves_like 'debian-install', 'Debian', 'wheezy'
-    it_behaves_like 'debian-install', 'Ubuntu', 'precise'
+    it_behaves_like 'debian-install', 'Ubuntu', 'trusty'
   end
 
   context 'without cron' do
@@ -47,7 +45,6 @@ describe 'zookeeper::install' do
 
     it { should contain_package('zookeeper') }
     it { should contain_package('zookeeperd') }
-    it { should_not contain_package('cron') }
   end
 
 
@@ -70,7 +67,6 @@ describe 'zookeeper::install' do
       'ensure'  => 'absent',
       })
     }
-    it { should_not contain_package('cron') }
   end
 
 

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -12,4 +12,47 @@ describe 'zookeeper::service' do
     :ensure => 'running',
     :enable => true
   )}
+
+
+  context 'restart zookeeper default' do
+    it { should contain_file(
+      '/etc/zookeeper/conf/myid'
+    ).that_notifies('Service[zookeeper]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).that_notifies('Service[zookeeper]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/environment'
+    ).that_notifies('Service[zookeeper]') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/log4j.properties'
+    ).that_notifies('Service[zookeeper]') }
+  end
+
+  context 'restart zookeeper false' do
+    let(:params)  {{
+      :restart_zookeeper => false
+
+    }}
+    it { should contain_file(
+      '/etc/zookeeper/conf/myid') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/environment') }
+    it { should contain_file(
+      '/etc/zookeeper/conf/log4j.properties') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/myid'
+    ).that_notifies('Service[zookeeper]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).that_notifies('Service[zookeeper]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/environment'
+    ).that_notifies('Service[zookeeper]') }
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/log4j.properties'
+    ).that_notifies('Service[zookeeper]') }
+  end
 end


### PR DESCRIPTION
      Fix rspec tests and rake. (for https://jira.yelpcorp.com/browse/ZOOKEEPER-160)
      
      Also fix the restarting of zookeeper service when files are changed.
      
      There was a dependency loop which meant that if restart_zookeeper were
      true, the notify was being set up before service was actually defined.
      
      Bunch of minor fixes.


Tested with `puppet-bundle exec rake spec`  which actually runs now and is green.

Also, tested with wwho and run-puppet on nodes where it is no-op.

Tests pass on travis as well now.