### PR TITLE
Creating 'version-2' dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,7 +81,7 @@ class zookeeper::config(
     mode   => '0644',
   }
 
-  file { $datastore:
+  file { [$datastore, "${datastore}/version-2"]:
     ensure => directory,
     owner  => $user,
     group  => $group,


### PR DESCRIPTION
Most common location for the datalogdir is within
the version-2 zk data directory, this is only created
by the zookeeper daemon currently, so needs to be added to
the manifests to prevent catalog failures