### PR TITLE
Added peertype config to the zookeeper module

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,6 +42,7 @@ class zookeeper::config(
   $zoo_main              = 'org.apache.zookeeper.server.quorum.QuorumPeerMain',
   $log4j_prop            = 'INFO,ROLLINGFILE',
   $servers               = [''],
+  $is_observer           = false,
   # since zookeeper 3.4, for earlier version cron task might be used
   $snap_retain_count     = 3,
   # interval in hours, purging enabled when >= 1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class zookeeper(
   $log4j_prop  = 'INFO,ROLLINGFILE',
   $cleanup_sh  = '/usr/share/zookeeper/bin/zkCleanup.sh',
   $servers     = [''],
+  $is_observer = false,
   $ensure      = present,
   $snap_count  = 10000,
   # since zookeeper 3.4, for earlier version cron task might be used
@@ -74,6 +75,7 @@ class zookeeper(
     zoo_main                 => $zoo_main,
     log4j_prop               => $log4j_prop,
     servers                  => $servers,
+    is_observer              => $is_observer,
     snap_count               => $snap_count,
     snap_retain_count        => $snap_retain_count,
     purge_interval           => $purge_interval,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -130,4 +130,28 @@ describe 'zookeeper::config' do
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/dataLogDir=\/tmp\/log/) }
   end
+
+  context 'is_observer is set to true' do
+    is_observer = true
+
+    let(:params) {{
+      :is_observer => is_observer
+    }}
+
+    it { should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/peerType=observer/) }
+  end
+
+  context 'is_observer is set to false' do
+    is_observer = false
+
+    let(:params) {{
+      :is_observer => is_observer
+    }}
+
+    it { should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).without_content(/peerType=observer/) }
+  end
 end

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -74,4 +74,4 @@ quorumListenOnAllIPs=<%= scope.lookupvar('zookeeper::config::quorum_listen_on_al
 # Mark this node as an observer, if needed
 <% if scope.lookupvar('zookeeper::config::is_observer') %>
 peerType=observer
-<% end%>
+<% end %>

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -70,3 +70,8 @@ maxClientCnxns=<%= scope.lookupvar('zookeeper::config::max_allowed_connections')
 # Listen for connections from peers on all available IPs
 # Default is false; but, at Yelp, via Puppet the default is set to true
 quorumListenOnAllIPs=<%= scope.lookupvar('zookeeper::config::quorum_listen_on_all_ips') %>
+
+# Mark this node as an observer, if needed
+<% if scope.lookupvar('zookeeper::config::is_observer') %>
+peerType=observer
+<% end%>


### PR DESCRIPTION
## What?

This will add the `peerType=observer` line to `zoo.cfg` when it is specified via the `zookeeper_cluster` module.

The modified server list will also be passed via the `zookeeper_cluster` module which will do all the heavy lifting.

## Testing
`puppet-bundle exec rake spec` passes