### PR TITLE
DREIMP-6337: Making the global limit configurable for zookeeper

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,7 @@ class zookeeper::config(
   $datalogstore          = undef,
   $client_port           = 2181,
   $snap_count            = 10000,
+  $global_req_limit      = 1000,
   $log_dir               = '/var/log/zookeeper',
   $cfg_dir               = '/etc/zookeeper/conf',
   $user                  = 'zookeeper',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -69,10 +69,12 @@ describe 'zookeeper::config' do
 
   context 'extra parameters' do
     snap_cnt = 15000
+    global_req_limit = 1100
     # set custom params
     let(:params) { {
-      :log4j_prop    => 'INFO,ROLLINGFILE',
-      :snap_count    => snap_cnt,
+      :log4j_prop       => 'INFO,ROLLINGFILE',
+      :snap_count       => snap_cnt,
+      :global_req_limit => global_req_limit,
     } }
 
     it {
@@ -81,6 +83,10 @@ describe 'zookeeper::config' do
 
     it {
       should contain_file('/etc/zookeeper/conf/zoo.cfg').with_content(/snapCount=15000/)
+    }
+
+    it {
+      should contain_file('/etc/zookeeper/conf/zoo.cfg').with_content(/globalOutstandingLimit=1100/)
     }
   end
 

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -42,6 +42,9 @@ preAllocSize=<%= scope.lookupvar('zookeeper::config::txn_log_prealloc_size') %>
 # snapshot is started and a new transaction log file is started. The default
 # snapCount is 10,000.
 snapCount=<%= scope.lookupvar('zookeeper::config::snap_count') %>
+<% if scope.lookupvar('zookeeper::config::global_req_limit') %>
+globalOutstandingLimit=<%= scope.lookupvar('zookeeper::config::global_req_limit') %>
+<% end%>
 
 # If this option is defined, requests will be will logged to a trace file named
 # traceFile.year.month.day.


### PR DESCRIPTION
Makes `globalOutstandingLimit` configurable through puppet.

(https://zookeeper.apache.org/doc/r3.4.6/zookeeperAdmin.html)


### Verification
```
zookeeper::config
  on debian-like system
    behaves like debian-install
Notice: Compiled catalog in 1.78 seconds
      should contain File[/etc/zookeeper/conf] with ensure => "directory", owner => "zookeeper" and group => "zookeeper"
      should contain File[/var/lib/zookeeper] with ensure => "directory", owner => "zookeeper" and group => "zookeeper"
      should contain File[/etc/zookeeper/conf/myid] with ensure => "file", owner => "zookeeper", group => "zookeeper" and content =~ /1/
      should contain File[/etc/zookeeper/conf/environment] with owner => "zookeeper", group => "zookeeper" and content =~ /NAME=zookeeper/
  custom parameters
    behaves like debian-install
      should contain File[/var/lib/zookeeper/conf] with ensure => "directory", owner => "zoo" and group => "zoo"
      should contain File[/var/lib/zookeeper/log] with ensure => "directory", owner => "zoo" and group => "zoo"
      should contain File[/var/lib/zookeeper/conf/myid] with ensure => "file", owner => "zoo", group => "zoo" and content =~ /2/
      should contain File[/var/lib/zookeeper/conf/environment] with owner => "zoo", group => "zoo" and content =~ /NAME=zookeeper/
  extra parameters
    should contain File[/etc/zookeeper/conf/environment] with content =~ /INFO,ROLLINGFILE/
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /snapCount=15000/
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /globalOutstandingLimit=1100/
  log4j file
    should contain File[/etc/zookeeper/conf/log4j.properties] with ensure => "link" and target => "/nail/etc/zookeeper/log4j.properties"
  max allowed connections
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /maxClientCnxns=15/
  quorum listen on all ips
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /quorumListenOnAllIPs=false/
  datalogstore
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /dataLogDir=\/tmp\/log/
  is_observer is set to true
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /peerType=observer/
  is_observer is set to false
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content !~ /peerType=observer/
```