### PR TITLE
Fixing the init manifest files for exposing the global_req_limit attribute

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class zookeeper(
   $is_observer = false,
   $ensure      = present,
   $snap_count  = 10000,
+  $global_req_limit = 1000,
   # since zookeeper 3.4, for earlier version cron task might be used
   $snap_retain_count = 3,
   # interval in hours, purging enabled when >= 1
@@ -84,6 +85,7 @@ class zookeeper(
     servers                  => $servers,
     is_observer              => $is_observer,
     snap_count               => $snap_count,
+    global_req_limit         => $global_req_limit,
     snap_retain_count        => $snap_retain_count,
     purge_interval           => $purge_interval,
     rollingfile_threshold    => $rollingfile_threshold,


### PR DESCRIPTION
### Verification

```
zookeeper::config
  on debian-like system
    behaves like debian-install
Notice: Compiled catalog for dev152-uswest1adevc.uswest1-devc.yelpcorp.com in environment rp_env in 1.78 seconds
      should contain File[/etc/zookeeper/conf] with ensure => "directory", owner => "zookeeper" and group => "zookeeper"
      should contain File[/var/lib/zookeeper] with ensure => "directory", owner => "zookeeper" and group => "zookeeper"
      should contain File[/etc/zookeeper/conf/myid] with ensure => "file", owner => "zookeeper", group => "zookeeper" and content =~ /1/
      should contain File[/etc/zookeeper/conf/environment] with owner => "zookeeper", group => "zookeeper" and content =~ /NAME=zookeeper/
  custom parameters
    behaves like debian-install
      should contain File[/var/lib/zookeeper/conf] with ensure => "directory", owner => "zoo" and group => "zoo"
      should contain File[/var/lib/zookeeper/log] with ensure => "directory", owner => "zoo" and group => "zoo"
      should contain File[/var/lib/zookeeper/conf/myid] with ensure => "file", owner => "zoo", group => "zoo" and content =~ /2/
      should contain File[/var/lib/zookeeper/conf/environment] with owner => "zoo", group => "zoo" and content =~ /NAME=zookeeper/
  extra parameters
    should contain File[/etc/zookeeper/conf/environment] with content =~ /INFO,ROLLINGFILE/
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /snapCount=15000/
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /globalOutstandingLimit=1100/
  log4j file
    should contain File[/etc/zookeeper/conf/log4j.properties] with ensure => "link" and target => "/nail/etc/zookeeper/log4j.properties"
  max allowed connections
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /maxClientCnxns=15/
  quorum listen on all ips
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /quorumListenOnAllIPs=false/
  datalogstore
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /dataLogDir=\/tmp\/log/
  is_observer is set to true
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content =~ /peerType=observer/
  is_observer is set to false
    should contain File[/etc/zookeeper/conf/zoo.cfg] with content !~ /peerType=observer/
```