### PR TITLE
Replace legacy validate_ functions with appropriate typing

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,7 +56,7 @@ class zookeeper::config(
   $tick_time = 2000,
   $init_limit = 10,
   $sync_limit = 5,
-  $log4j_file = undef,
+  Stdlib::Absolutepath $log4j_file = undef,
   $txn_log_prealloc_size = 65536,
   $zookeeper_minor_version = "3.4",
   $local_sessions_enabled = false,
@@ -65,7 +65,6 @@ class zookeeper::config(
   require zookeeper::install
 
   if $log4j_file {
-    validate_absolute_path($log4j_file)
     if $log4j_file == "${cfg_dir}/log4j.properties" {
         fail('log4j_file should not be same as ' + "${cfg_dir}/log4j.properties")
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,19 +44,17 @@ class zookeeper(
   $rollingfile_threshold = 'ERROR',
   $tracefile_threshold    = 'TRACE',
   $max_allowed_connections = 10,
-  $quorum_listen_on_all_ips = true,
+  Boolean $quorum_listen_on_all_ips = true,
   $tick_time = 2000,
   $init_limit = 10,
   $sync_limit = 5,
-  $restart_zookeeper = true,
+  Boolean $restart_zookeeper = true,
   $txn_log_prealloc_size,
   $zookeeper_minor_version = "3.4",
-  $local_sessions_enabled = false,
-  $local_sessions_upgrading_enabled = true,
+  Boolean $local_sessions_enabled = false,
+  Boolean $local_sessions_upgrading_enabled = true,
 
 ) {
-
-  validate_bool($quorum_listen_on_all_ips)
 
   $config_init_flag_val = ($zookeeper_minor_version == "3.4") ? {
     true  => false,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,12 +2,10 @@
 
 class zookeeper::service(
   $cfg_dir = '/etc/zookeeper/conf',
-  $restart_zookeeper = true,
+  Boolean $restart_zookeeper = true,
 ){
   require zookeeper::install
   require zookeeper::config
-  validate_bool($restart_zookeeper)
-
 
   service { 'zookeeper':
     ensure     => 'running',


### PR DESCRIPTION
The validate_ functions are no longer available in Puppet Stdlib 9.x. We can replace them with the typing system here, which will throw a failure identically to how those functioned. 

This won't take effect until the Puppetfile in our Puppet repo is updated, so this would be safe to merge.