### PR TITLE
Add environment.3.8.erb for ZooKeeper 3.8 support

### DIFF
--- a/templates/conf/environment.3.8.erb
+++ b/templates/conf/environment.3.8.erb
@@ -1,0 +1,14 @@
+NAME=zookeeper
+ZOOCFGDIR=<%= scope.lookupvar('zookeeper::config::cfg_dir') %>
+
+ZOOCFG="zoo.cfg"
+ZOO_LOG_DIR=<%= scope.lookupvar('zookeeper::config::log_dir') %>
+USER=<%= scope.lookupvar('zookeeper::config::user') %>
+GROUP=<%= scope.lookupvar('zookeeper::config::group') %>
+PIDDIR=<%= scope.lookupvar('zookeeper::config::pid_dir') %>
+PIDFILE=<%= scope.lookupvar('zookeeper::config::pid_file') %>
+SCRIPTNAME=/etc/init.d/$NAME
+JAVA=<%= scope.lookupvar('zookeeper::config::java_bin') %>
+ZOOMAIN="<%= scope.lookupvar('zookeeper::config::zoo_main') %>"
+JMXLOCALONLY=false
+JAVA_OPTS="<%= scope.lookupvar('zookeeper::config::java_opts') %>"


### PR DESCRIPTION
ZK 3.8 migrated from log4j to logback (ZOOKEEPER-4427). The ZOO_LOG4J_PROP environment variable is no longer used in 3.8 — logback handles logging configuration via logback.xml.

This template is identical to environment.3.6.erb but with ZOO_LOG4J_PROP removed.